### PR TITLE
[Feat] Swagger 설정 및 공통 응답 구조 설계

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/example/off/common/config/SwaggerConfig.java
+++ b/src/main/java/com/example/off/common/config/SwaggerConfig.java
@@ -1,0 +1,35 @@
+package com.example.off.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        String jwt = "JWT";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt);
+        Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
+                .name(jwt)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+        );
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo())
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+    private Info apiInfo() {
+        return new Info()
+                .title("OFF API 명세서") // API의 제목
+                .description("OFF의 API 명세서 입니다!") // API에 대한 설명
+                .version("1.0.0"); // API의 버전
+    }
+}

--- a/src/main/java/com/example/off/common/exception/OffControllerAdvice.java
+++ b/src/main/java/com/example/off/common/exception/OffControllerAdvice.java
@@ -19,7 +19,7 @@ public class OffControllerAdvice {
         log.error("BaseException: {}", e.getMessage());
         ResponseCode responseCode = e.getResponseCode();
         return ResponseEntity
-                .status(HttpStatus.valueOf(responseCode.getCode())) // 혹은 상황에 맞는 HTTP Status
+                .status(responseCode.getHttpStatus()) // 혹은 상황에 맞는 HTTP Status
                 .body(new BaseResponse<>(responseCode));
     }
 

--- a/src/main/java/com/example/off/common/exception/OffControllerAdvice.java
+++ b/src/main/java/com/example/off/common/exception/OffControllerAdvice.java
@@ -1,0 +1,36 @@
+package com.example.off.common.exception;
+
+import com.example.off.common.response.BaseResponse;
+import com.example.off.common.response.ResponseCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class OffControllerAdvice {
+    /**
+     * 커스텀 예외 처리 (비즈니스 로직 중 발생하는 예외)
+     */
+    @ExceptionHandler(OffException.class)
+    public ResponseEntity<BaseResponse<Void>> handleBaseException(OffException e) {
+        log.error("BaseException: {}", e.getMessage());
+        ResponseCode responseCode = e.getResponseCode();
+        return ResponseEntity
+                .status(HttpStatus.valueOf(responseCode.getCode())) // 혹은 상황에 맞는 HTTP Status
+                .body(new BaseResponse<>(responseCode));
+    }
+
+    /**
+     * 예상치 못한 일반적인 예외 처리
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<BaseResponse<Void>> handleException(Exception e) {
+        log.error("Internal Server Error: ", e);
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new BaseResponse<>(ResponseCode.INTERNAL_SERVER_ERROR)); // Enum에 미리 정의 필요
+    }
+}

--- a/src/main/java/com/example/off/common/exception/OffException.java
+++ b/src/main/java/com/example/off/common/exception/OffException.java
@@ -1,0 +1,35 @@
+package com.example.off.common.exception;
+
+import com.example.off.common.response.ResponseCode;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+public class OffException extends RuntimeException {
+    private static final String APP_PACKAGE_PREFIX = "com.example.off";
+    private final ResponseCode responseCode;
+
+    public OffException(ResponseCode responseCode) {
+        super(responseCode.getMessage());
+        this.responseCode = responseCode;
+
+        StackTraceElement[] stackTrace = getStackTrace();
+
+        StringBuilder filtered = new StringBuilder();
+
+        filtered.append(this.getClass().getSimpleName())
+                .append(" - message : ")
+                .append(responseCode.getMessage())
+                .append("\n");
+
+        for (StackTraceElement element : stackTrace) {
+            if (element.getClassName().startsWith(APP_PACKAGE_PREFIX)) {
+                filtered.append("\tat ").append(element).append("\n");
+            }
+        }
+
+        log.warn(filtered.toString());
+    }
+
+}

--- a/src/main/java/com/example/off/common/response/BaseResponse.java
+++ b/src/main/java/com/example/off/common/response/BaseResponse.java
@@ -1,0 +1,38 @@
+package com.example.off.common.response;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@JsonPropertyOrder({"success", "code", "message", "data"})
+public class BaseResponse<T> {
+    @Schema(description = "성공 여부", example = "true")
+    private final boolean success;
+
+    @Schema(description = "응답 코드", example = "200")
+    private final int code;
+
+    @Schema(description = "응답 메세지", example = "요청에 성공하였습니다.")
+    private final String message;
+
+    private final T data;
+
+    public BaseResponse(ResponseCode responseCode, T result) {
+        this.success = responseCode.isSuccess();
+        this.code = responseCode.getCode();
+        this.message = responseCode.getMessage();
+        this.data = result;
+    }
+
+    public BaseResponse(ResponseCode responseCode) {
+        this.success = responseCode.isSuccess();
+        this.code = responseCode.getCode();
+        this.message = responseCode.getMessage();
+        this.data = null;
+    }
+
+    public static <T> BaseResponse<T> ok(T result) {
+        return new BaseResponse<>(ResponseCode.SUCCESS, result);
+    }
+}

--- a/src/main/java/com/example/off/common/response/ResponseCode.java
+++ b/src/main/java/com/example/off/common/response/ResponseCode.java
@@ -1,0 +1,31 @@
+package com.example.off.common.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public enum ResponseCode {
+    // 테스트
+    TEST_EXCEPTION(true, 100, "테스트용 예외입니다."),
+
+    // global 요청 성공
+    SUCCESS(true, 200, "요청에 성공하였습니다."),
+
+    // 공통 에러
+    INVALID_PATH_VARIABLE_TYPE(false, 400, "요청 경로에 포함된 값의 타입이 올바르지 않습니다. 올바른 형식으로 요청해주세요."),
+    BAD_REQUEST(false, 400, "유효하지 않은 요청입니다."),
+    API_NOT_FOUND(false, 404, "존재하지 않는 API입니다."),
+    METHOD_NOT_ALLOWED(false, 405, "유효하지 않은 Http 메서드입니다."),
+    INTERNAL_SERVER_ERROR(false, 500, "서버 내부 오류입니다.");
+
+    private boolean isSuccess;
+    private int code;
+    private String message;
+}

--- a/src/main/java/com/example/off/common/response/ResponseCode.java
+++ b/src/main/java/com/example/off/common/response/ResponseCode.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
@@ -13,19 +14,20 @@ import lombok.NoArgsConstructor;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public enum ResponseCode {
     // 테스트
-    TEST_EXCEPTION(true, 100, "테스트용 예외입니다."),
+    TEST_EXCEPTION(true, 100, "테스트용 예외입니다.", HttpStatus.OK),
 
     // global 요청 성공
-    SUCCESS(true, 200, "요청에 성공하였습니다."),
+    SUCCESS(true, 200, "요청에 성공하였습니다.", HttpStatus.OK),
 
     // 공통 에러
-    INVALID_PATH_VARIABLE_TYPE(false, 400, "요청 경로에 포함된 값의 타입이 올바르지 않습니다. 올바른 형식으로 요청해주세요."),
-    BAD_REQUEST(false, 400, "유효하지 않은 요청입니다."),
-    API_NOT_FOUND(false, 404, "존재하지 않는 API입니다."),
-    METHOD_NOT_ALLOWED(false, 405, "유효하지 않은 Http 메서드입니다."),
-    INTERNAL_SERVER_ERROR(false, 500, "서버 내부 오류입니다.");
+    INVALID_PATH_VARIABLE_TYPE(false, 400, "요청 경로에 포함된 값의 타입이 올바르지 않습니다. 올바른 형식으로 요청해주세요.", HttpStatus.BAD_REQUEST),
+    BAD_REQUEST(false, 400, "유효하지 않은 요청입니다.", HttpStatus.BAD_REQUEST),
+    API_NOT_FOUND(false, 404, "존재하지 않는 API입니다.", HttpStatus.NOT_FOUND),
+    METHOD_NOT_ALLOWED(false, 405, "유효하지 않은 Http 메서드입니다.", HttpStatus.METHOD_NOT_ALLOWED),
+    INTERNAL_SERVER_ERROR(false, 500, "서버 내부 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private boolean isSuccess;
     private int code;
     private String message;
+    private HttpStatus httpStatus;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #9 

## 📝작업 내용

> 스웨거 설정, 공통 응답 구조, 오류 코드 클래스 만들었고, 예외 처리 컨트롤러를 만들었으니 try - catch 안 하셔도 됩니다. 

이를테면,

```java
@GetMapping("/users/{id}")
public BaseResponse<UserResponse> getUser(@PathVariable Long id) {
    User user = userRepository.findById(id)
        .orElseThrow(() -> new OffException(ResponseCode.USER_NOT_FOUND)); // 예외 발생!
    
    return BaseResponse.ok(new UserResponse(user));
 }
```
이런 식으로 상황에 맞는 코드 값으로 예외를 던져주시기만 하면 됩니다.
코드는 일부 공통적인 사안에 대해서는 작성해놨으나, 각자 구현하시면서 코드를 추가하셔야합니다. 

### 스크린샷 (선택)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/241fa9c9-2d0f-4711-bd2f-ad456a45b883" />

## 💬리뷰 요구사항(선택)

> Controller에서 OffException 을 throw 하면 OffControllerAdvice 가 작동하여 처리하는 구조입니다. 