### PR TITLE
[Feat] 알림 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
 	// Swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
-
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/example/off/common/response/ResponseCode.java
+++ b/src/main/java/com/example/off/common/response/ResponseCode.java
@@ -24,7 +24,11 @@ public enum ResponseCode {
     BAD_REQUEST(false, 400, "유효하지 않은 요청입니다.", HttpStatus.BAD_REQUEST),
     API_NOT_FOUND(false, 404, "존재하지 않는 API입니다.", HttpStatus.NOT_FOUND),
     METHOD_NOT_ALLOWED(false, 405, "유효하지 않은 Http 메서드입니다.", HttpStatus.METHOD_NOT_ALLOWED),
-    INTERNAL_SERVER_ERROR(false, 500, "서버 내부 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    INTERNAL_SERVER_ERROR(false, 500, "서버 내부 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+
+    // 알림
+    NOTIFICATION_NOT_FOUND(false, 404, "알림을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    BAD_NOTIFICATION_REQUEST(false, 400, "유효하지 않은 요청입니다.", HttpStatus.BAD_REQUEST);
 
     private boolean isSuccess;
     private int code;

--- a/src/main/java/com/example/off/domain/notification/Notification.java
+++ b/src/main/java/com/example/off/domain/notification/Notification.java
@@ -47,4 +47,8 @@ public class Notification {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    public void read() {
+        this.isRead = true;
+    }
 }

--- a/src/main/java/com/example/off/domain/notification/NotificationType.java
+++ b/src/main/java/com/example/off/domain/notification/NotificationType.java
@@ -1,5 +1,8 @@
 package com.example.off.domain.notification;
 
+import lombok.Getter;
+
+@Getter
 public enum NotificationType {
     INVITE("파트너 매칭"),
     CHAT("채팅"),

--- a/src/main/java/com/example/off/domain/notification/NotificationType.java
+++ b/src/main/java/com/example/off/domain/notification/NotificationType.java
@@ -1,7 +1,13 @@
 package com.example.off.domain.notification;
 
 public enum NotificationType {
-    INVITE,
-    CHAT,
-    PAY;
+    INVITE("파트너 매칭"),
+    CHAT("채팅"),
+    PAY("결제");
+
+    private final String description;
+
+    NotificationType(String description) {
+        this.description = description;
+    }
 }

--- a/src/main/java/com/example/off/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/off/domain/notification/controller/NotificationController.java
@@ -1,0 +1,43 @@
+package com.example.off.domain.notification.controller;
+
+import com.example.off.common.response.BaseResponse;
+import com.example.off.domain.notification.dto.NotificationListResponse;
+import com.example.off.domain.notification.dto.NotificationReadResponse;
+import com.example.off.domain.notification.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Notification", description = "알림 관련 API")
+@RestController
+@RequestMapping("/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @Operation(summary = "알림 목록 조회", description = "커서 기반 페이징 및 자동 읽음 처리가 포함된 알림 목록을 조회합니다.")
+    @GetMapping
+    public BaseResponse<NotificationListResponse> getNotifications(
+            @RequestParam(name = "memberId", defaultValue = "1") Long memberId,
+            @Parameter(description = "마지막으로 조회된 알림 ID (첫 페이지 조회 시 null)")
+            @RequestParam(required = false) Long cursor,
+            @Parameter(description = "한 번에 조회할 알림 개수 (기본값 10)")
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        NotificationListResponse data = notificationService.getNotifications(memberId, cursor, size);
+        return BaseResponse.ok(data);
+    }
+
+    @Operation(summary = "URL 알림 읽음 처리", description = "URL이 포함된 알림을 클릭했을 때 읽음 상태로 변경합니다.")
+    @PatchMapping("/{notificationId}/read")
+    public BaseResponse<NotificationReadResponse> readNotification(
+            @RequestParam(name = "memberId", defaultValue = "1") Long memberId,
+            @PathVariable Long notificationId
+    ) {
+        NotificationReadResponse data = notificationService.readUrlNotification(memberId, notificationId);
+        return BaseResponse.ok(data);
+    }
+}

--- a/src/main/java/com/example/off/domain/notification/dto/NotificationListResponse.java
+++ b/src/main/java/com/example/off/domain/notification/dto/NotificationListResponse.java
@@ -1,9 +1,11 @@
 package com.example.off.domain.notification.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 import java.util.List;
 
+@Getter
 @AllArgsConstructor
 public class NotificationListResponse {
     private int unReadCount;

--- a/src/main/java/com/example/off/domain/notification/dto/NotificationListResponse.java
+++ b/src/main/java/com/example/off/domain/notification/dto/NotificationListResponse.java
@@ -1,0 +1,16 @@
+package com.example.off.domain.notification.dto;
+
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+public class NotificationListResponse {
+    private int unReadCount;
+    private List<NotificationResponse> notifications;
+    private boolean hasNext;
+
+    public static NotificationListResponse of(int unReadCount, List<NotificationResponse> notifications, boolean hasNext){
+        return new NotificationListResponse(unReadCount, notifications, hasNext);
+    }
+}

--- a/src/main/java/com/example/off/domain/notification/dto/NotificationReadResponse.java
+++ b/src/main/java/com/example/off/domain/notification/dto/NotificationReadResponse.java
@@ -1,0 +1,7 @@
+package com.example.off.domain.notification.dto;
+
+public record NotificationReadResponse(
+    Long notificationId,
+    boolean isRead
+) {
+}

--- a/src/main/java/com/example/off/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/example/off/domain/notification/dto/NotificationResponse.java
@@ -1,0 +1,25 @@
+package com.example.off.domain.notification.dto;
+
+import com.example.off.domain.notification.Notification;
+
+public record NotificationResponse(
+        Long notificationId,
+        String title,
+        String type,
+        String content,
+        String redirectUrl,
+        String createdAt,
+        boolean isRead
+) {
+    public static NotificationResponse from(Notification notification) {
+        return new NotificationResponse(
+                notification.getId(),
+                notification.getNotificationType().getDescription(),
+                notification.getNotificationType().name(),
+                notification.getContent(),
+                notification.getUrl(),
+                notification.getCreatedAt().toString(),
+                notification.getIsRead()
+        );
+    }
+}

--- a/src/main/java/com/example/off/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/example/off/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,22 @@
+package com.example.off.domain.notification.repository;
+
+import com.example.off.domain.notification.Notification;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    @Query("SELECT n FROM Notification n " + "WHERE n.member.id = :memberId " +
+            "AND (:cursor IS NULL OR n.id < :cursor) " + "ORDER BY n.id DESC")
+    List<Notification> findAllByMemberIdAndCursor(
+            @Param("memberId") Long memberId,
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
+
+    @Query("SELECT COUNT(n) FROM Notification n " + "WHERE n.member.id = :memberId AND n.isRead = false")
+    int countUnreadByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/example/off/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/off/domain/notification/service/NotificationService.java
@@ -1,0 +1,37 @@
+package com.example.off.domain.notification.service;
+
+import com.example.off.domain.notification.Notification;
+import com.example.off.domain.notification.dto.NotificationListResponse;
+import com.example.off.domain.notification.dto.NotificationResponse;
+import com.example.off.domain.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+    private final NotificationRepository notificationRepository;
+
+    public NotificationListResponse getNotifications(Long memberId, Long cursor, int size) {
+        int totalUnread = notificationRepository.countUnreadByMemberId(memberId);
+        List<Notification> notifications = notificationRepository.findAllByMemberIdAndCursor(memberId, cursor,
+                PageRequest.of(0, size + 1));
+        boolean hasNext = notifications.size() > size;
+
+        List<Notification> autoReadList = notifications.stream().limit(size)
+                .filter(n -> n.getUrl() == null && !n.getIsRead()).peek(Notification::read).toList();
+        long autoReadCount = autoReadList.size();
+        int finalUnreadCount = Math.max(0, totalUnread - (int)autoReadCount);
+
+        List<NotificationResponse> notificationResponses = notifications.stream().limit(size)
+                .map(NotificationResponse::from).toList();
+
+        return NotificationListResponse.of(finalUnreadCount, notificationResponses, hasNext);
+    }
+}

--- a/src/main/java/com/example/off/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/off/domain/notification/service/NotificationService.java
@@ -1,12 +1,14 @@
 package com.example.off.domain.notification.service;
 
+import com.example.off.common.exception.OffException;
+import com.example.off.common.response.ResponseCode;
 import com.example.off.domain.notification.Notification;
 import com.example.off.domain.notification.dto.NotificationListResponse;
+import com.example.off.domain.notification.dto.NotificationReadResponse;
 import com.example.off.domain.notification.dto.NotificationResponse;
 import com.example.off.domain.notification.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,5 +35,20 @@ public class NotificationService {
                 .map(NotificationResponse::from).toList();
 
         return NotificationListResponse.of(finalUnreadCount, notificationResponses, hasNext);
+    }
+
+    public NotificationReadResponse readUrlNotification(Long memberId, Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .filter(n -> n.getMember().getId().equals(memberId))
+                .orElseThrow(() -> new OffException(ResponseCode.NOTIFICATION_NOT_FOUND));
+
+        if (notification.getUrl() == null) {
+            throw new OffException(ResponseCode.BAD_NOTIFICATION_REQUEST);
+        }
+
+        if (!notification.getIsRead()) {
+            notification.read();
+        }
+        return new NotificationReadResponse(notification.getId(), notification.getIsRead());
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,6 @@
 spring:
   application:
     name: off
+springdoc:
+  api-docs:
+    version: openapi_3_0  # 3.1.0 대신 3.0.x 계열을 사용하도록 강제함


### PR DESCRIPTION
## #️⃣연관된 이슈

> #11 

## 📝작업 내용

> 유저의 알림 목록 조회와 url 존재 알림의 읽음 api를 구현했습니다.

### 스크린샷 (선택)
<img width="517" height="500" alt="image" src="https://github.com/user-attachments/assets/362046a8-acc3-4ca7-a827-935102ca8e26" />
<img width="827" height="608" alt="image" src="https://github.com/user-attachments/assets/ade41d59-1790-4a42-be81-ff79fd6e9190" />
Swagger 화면 입니다.

## 💬리뷰 요구사항(선택)

>질문 사항 있으면 댓글 언제든 남겨주세요