### PR TITLE
[Fix] CORS 설정 추가 - 프론트엔드 API 호출 허용

### DIFF
--- a/src/main/java/com/example/off/common/config/WebConfig.java
+++ b/src/main/java/com/example/off/common/config/WebConfig.java
@@ -1,0 +1,24 @@
+package com.example.off.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")  // 모든 경로에 대해
+                .allowedOrigins(
+                        "http://localhost:5173",      // 로컬 개발 (Vite)
+                        "http://localhost:3000",      // 로컬 개발 (React)
+                        "http://offf.kro.kr",         // 프로덕션
+                        "https://offf.kro.kr"         // 프로덕션 HTTPS
+                )
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);  // preflight 요청 캐시 시간 (1시간)
+    }
+}


### PR DESCRIPTION
## 🐛 문제 상황

프론트엔드(localhost:5173)에서 백엔드 API(offf.kro.kr:8080)를 호출할 때 CORS 에러가 발생하여 회원가입/로그인이 불가능한 상황이었습니다.

```
Access to XMLHttpRequest at 'http://offf.kro.kr:8080/auth/signup' 
from origin 'http://localhost:5173' has been blocked by CORS policy: 
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

## ✅ 해결 방법

`WebConfig.java` 추가하여 전역 CORS 설정을 구성했습니다.

### 주요 변경사항

- ✅ **허용된 Origin**
  - `http://localhost:5173` (Vite 개발 서버)
  - `http://localhost:3000` (React 개발 서버)
  - `http://offf.kro.kr` (프로덕션)
  - `https://offf.kro.kr` (프로덕션 HTTPS)

- ✅ **허용된 HTTP 메서드**
  - GET, POST, PUT, PATCH, DELETE, OPTIONS

- ✅ **인증 정보 허용**
  - `allowCredentials(true)` - JWT 토큰 포함 요청 지원

- ✅ **Preflight 캐싱**
  - 1시간 동안 OPTIONS 요청 결과 캐시

## 📝 변경된 파일

- `src/main/java/com/example/off/common/config/WebConfig.java` (신규 생성)

## 🧪 테스트

프론트엔드에서 다음 API 호출이 정상 작동하는지 확인:
- [x] 회원가입 (`POST /auth/signup`)
- [x] 로그인 (`POST /auth/login`)
- [x] 기타 모든 REST API

## 🚀 배포 후 확인 사항

배포 후 프론트엔드에서 CORS 에러 없이 API 호출이 정상 작동하는지 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)