### PR TITLE
Hotfix: Gemini 모델명에 -latest suffix 추가

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,7 +29,7 @@ springdoc:
 
 gemini:
   api-key: ${GEMINI_API_KEY}
-  url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent"
+  url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent"
 
 jwt:
   secret: ${JWT_SECRET}      # 들여쓰기 수정됨


### PR DESCRIPTION
## 🐛 긴급 수정

이전 PR에서  suffix가 빠져서 404 에러 발생

## 🔧 변경사항
```yaml
# Before
url: "...models/gemini-1.5-flash:generateContent"

# After  
url: "...models/gemini-1.5-flash-latest:generateContent"
```

## ✅ 테스트
- [ ] 배포 후 Swagger에서 `/projects/estimate` API 호출
- [ ] 로그에서 404 에러 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)