### PR TITLE
Hotfix: Gemini 3.0 Flash로 모델 변경

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,7 +29,7 @@ springdoc:
 
 gemini:
   api-key: ${GEMINI_API_KEY}
-  url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent"
+  url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.0-flash:generateContent"
 
 jwt:
   secret: ${JWT_SECRET}      # 들여쓰기 수정됨


### PR DESCRIPTION
## 🔧 변경사항

`gemini-1.5-flash-latest` → `gemini-3.0-flash`

최신 Gemini 3.0 모델 사용으로 404 에러 해결

🤖 Generated with [Claude Code](https://claude.com/claude-code)