### PR TITLE
Fix: Gemini 2.5 Flash로 모델 변경 (확인 완료)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,7 +29,7 @@ springdoc:
 
 gemini:
   api-key: ${GEMINI_API_KEY}
-  url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.0-flash:generateContent"
+  url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
 
 jwt:
   secret: ${JWT_SECRET}      # 들여쓰기 수정됨


### PR DESCRIPTION
## ✅ ListModels API로 확인된 모델

```json
{
  "name": "models/gemini-2.5-flash",
  "supportedMethods": ["generateContent", "countTokens", "createCachedContent", "batchGenerateContent"]
}
```

## 🔧 변경사항
`gemini-3.0-flash` → `gemini-2.5-flash`

## ✅ 검증
- ListModels API로 실제 사용 가능한 모델 확인
- generateContent 메서드 지원 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)