### PR TITLE
Fix: Gemini JSON 응답 파싱 개선

### DIFF
--- a/src/main/java/com/example/off/domain/project/service/ProjectService.java
+++ b/src/main/java/com/example/off/domain/project/service/ProjectService.java
@@ -555,8 +555,24 @@ public class ProjectService {
     private ProjectEstimateResult parseProjectEstimateResult(
             String jsonResult, LocalDate startDate, List<RecruitmentInfo> recruitments) {
         try {
+            // 마크다운 코드 블록 제거 (Gemini가 ```json ... ``` 형식으로 반환하는 경우)
+            String cleanedJson = jsonResult.trim();
+            if (cleanedJson.startsWith("```")) {
+                // 첫 번째 줄 제거 (```json 또는 ```)
+                int firstNewline = cleanedJson.indexOf('\n');
+                if (firstNewline != -1) {
+                    cleanedJson = cleanedJson.substring(firstNewline + 1);
+                }
+                // 마지막 줄 제거 (```)
+                int lastBacktick = cleanedJson.lastIndexOf("```");
+                if (lastBacktick != -1) {
+                    cleanedJson = cleanedJson.substring(0, lastBacktick);
+                }
+                cleanedJson = cleanedJson.trim();
+            }
+
             ObjectMapper mapper = new ObjectMapper();
-            JsonNode root = mapper.readTree(jsonResult);
+            JsonNode root = mapper.readTree(cleanedJson);
 
             // 1. serviceSummary
             String serviceSummary = root.has("serviceSummary")


### PR DESCRIPTION
## 🐛 문제

Gemini API가 JSON 응답을 마크다운 코드 블록으로 감싸서 반환:
```
```json
{
  "data": "..."
}
```
```

파싱 에러 발생:
`Unexpected character ('`' (code 96))`

## 🔧 해결

`parseProjectEstimateResult` 메서드에 마크다운 코드 블록 제거 로직 추가:
- 응답 시작이 `````로 시작하면 첫 줄과 마지막 줄 제거
- 순수 JSON만 파싱

## ✅ 테스트
- [ ] Swagger에서 `/projects/estimate` API 호출
- [ ] 정상적인 견적 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)