### PR TITLE
Fix: CONTACT 타입 채팅방 조회 오류 및 프로젝트 생성 validation 추가

### DIFF
--- a/src/main/java/com/example/off/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/example/off/domain/chat/repository/ChatRoomMemberRepository.java
@@ -10,7 +10,15 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, Long> {
-    List<ChatRoomMember> findAllByMember_IdAndChatRoom_ChatType(Long memberId, ChatType chatRoomChatType);
+    @Query("SELECT crm FROM ChatRoomMember crm " +
+            "JOIN FETCH crm.chatRoom cr " +
+            "LEFT JOIN FETCH cr.project " +
+            "WHERE crm.member.id = :memberId AND cr.chatType = :chatType")
+    List<ChatRoomMember> findAllByMember_IdAndChatRoom_ChatType(
+            @Param("memberId") Long memberId,
+            @Param("chatType") ChatType chatType
+    );
+
     @Query("SELECT cp FROM ChatRoomMember cp " +
             "JOIN FETCH cp.member " +
             "WHERE cp.chatRoom.id = :roomId AND cp.member.id != :myId")

--- a/src/main/java/com/example/off/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/example/off/domain/project/controller/ProjectController.java
@@ -38,7 +38,7 @@ public class ProjectController {
     @PostMapping("/confirm")
     @CustomExceptionDescription(SwaggerResponseDescription.CONFIRM_PROJECT)
     public BaseResponse<ConfirmProjectResponse> confirmProject(
-            @RequestBody ConfirmProjectRequest request,
+            @Valid @RequestBody ConfirmProjectRequest request,
             HttpServletRequest httpServletRequest
     ) {
         Long memberId = getMemberId(httpServletRequest);

--- a/src/main/java/com/example/off/domain/project/dto/ConfirmProjectRequest.java
+++ b/src/main/java/com/example/off/domain/project/dto/ConfirmProjectRequest.java
@@ -1,5 +1,8 @@
 package com.example.off.domain.project.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,21 +11,31 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class ConfirmProjectRequest {
+    @NotBlank
     private String name;
     private String description;
     private Long projectTypeId = 1L;  // 앱개발로 고정 (1L = APP)
     private String requirement;
     private String serviceSummary;
+    @NotBlank
     private String endDate;
+    @NotNull
+    @Positive
     private Long totalEstimate;  // 원 단위
+    @NotNull
     private List<RecruitmentRequest> recruitmentList;
 
     @Getter
     @NoArgsConstructor
     public static class RecruitmentRequest {
+        @NotBlank
         private String roleId;
+        @NotNull
+        @Positive
         private Integer count;
-        private Long cost;  // 원 단위
+        @NotNull
+        @Positive
+        private Long cost;  // 원 단위 (필수)
         private List<Long> selectedPartnerIds;  // 선택한 파트너 ID 목록 (선택 사항)
     }
 }


### PR DESCRIPTION
## Summary
- CONTACT 타입 채팅방 목록 조회 시 발생하는 N+1 쿼리 문제 및 LAZY 로딩 오류 해결
- 프로젝트 확정 생성 시 cost 필드 누락으로 인한 500 에러 방지를 위한 validation 추가

## Changes
### ChatRoomMemberRepository
- `JOIN FETCH`로 ChatRoom과 Project를 즉시 로딩하여 N+1 쿼리 문제 해결
- `LEFT JOIN FETCH`로 project가 null인 CONTACT 타입 채팅방 지원

### ConfirmProjectRequest
- 필수 필드에 `@NotNull`, `@NotBlank`, `@Positive` validation 추가
- 특히 `cost` 필드를 필수로 지정하여 DB 제약 조건 위반 방지

### ProjectController
- `confirmProject` 메서드에 `@Valid` 어노테이션 추가하여 요청 검증 활성화

## Test plan
- [x] 빌드 성공 확인
- [ ] CONTACT 타입 채팅방 목록 조회 테스트
- [ ] cost 필드 없이 프로젝트 확정 생성 시 400 에러 반환 확인
- [ ] 정상적인 프로젝트 생성 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)