### PR TITLE
Fix: Validation 에러 핸들러 추가하여 500 에러 방지

### DIFF
--- a/src/main/java/com/example/off/common/exception/OffControllerAdvice.java
+++ b/src/main/java/com/example/off/common/exception/OffControllerAdvice.java
@@ -5,8 +5,12 @@ import com.example.off.common.response.ResponseCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
 
 @Slf4j
 @RestControllerAdvice
@@ -21,6 +25,21 @@ public class OffControllerAdvice {
         return ResponseEntity
                 .status(responseCode.getHttpStatus()) // 혹은 상황에 맞는 HTTP Status
                 .body(new BaseResponse<>(responseCode));
+    }
+
+    /**
+     * Validation 예외 처리 (@Valid 실패 시)
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<BaseResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
+        String errorMessage = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+
+        log.error("Validation Error: {}", errorMessage);
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new BaseResponse<>(ResponseCode.INVALID_INPUT_VALUE, "입력값이 유효하지 않습니다. " + errorMessage));
     }
 
     /**

--- a/src/main/java/com/example/off/common/response/BaseResponse.java
+++ b/src/main/java/com/example/off/common/response/BaseResponse.java
@@ -33,6 +33,13 @@ public class BaseResponse<T> {
         this.data = null;
     }
 
+    public BaseResponse(ResponseCode responseCode, String customMessage) {
+        this.success = responseCode.isSuccess();
+        this.code = responseCode.getCode();
+        this.message = customMessage;
+        this.data = null;
+    }
+
     public static <T> BaseResponse<T> ok(T result) {
         return new BaseResponse<>(ResponseCode.SUCCESS, result);
     }


### PR DESCRIPTION
## Summary
프로젝트 확정 생성 시 validation 실패 시 500 에러 대신 400 에러를 반환하도록 수정

## Problem
- `@Valid` 어노테이션으로 validation을 추가했지만, `MethodArgumentNotValidException` 핸들러가 없어서 validation 실패 시 500 에러 발생
- 프론트엔드에서 어떤 필드가 잘못되었는지 알 수 없음

## Solution
### OffControllerAdvice
- `MethodArgumentNotValidException` 핸들러 추가
- Validation 실패 시 400 에러와 함께 필드별 에러 메시지 반환
- 로그에 상세한 에러 정보 기록

### BaseResponse
- `ResponseCode`와 커스텀 메시지를 함께 받는 생성자 추가
- Validation 에러 메시지를 동적으로 생성 가능

## After This PR
이제 `cost` 필드 없이 요청하면:
```json
{
  "success": false,
  "code": 400,
  "message": "입력값이 유효하지 않습니다. recruitmentList[0].cost: must not be null",
  "data": null
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)