### PR TITLE
Feat: 지원 정보 조회 API 추가

### DIFF
--- a/src/main/java/com/example/off/domain/partnerRecruit/controller/PartnerMatchingController.java
+++ b/src/main/java/com/example/off/domain/partnerRecruit/controller/PartnerMatchingController.java
@@ -64,6 +64,15 @@ public class PartnerMatchingController {
         return BaseResponse.ok(partnerMatchingService.getPartnerProfile(partnerId));
     }
 
+    @Operation(summary = "지원 정보 조회", description = "지원 상세 정보를 조회합니다. (프로젝트 정보 포함)")
+    @GetMapping("/applications/{applicationId}")
+    @CustomExceptionDescription(SwaggerResponseDescription.GET_PARTNER_PROFILE)
+    public BaseResponse<ApplicationDetailResponse> getApplicationDetail(
+            @PathVariable Long applicationId
+    ) {
+        return BaseResponse.ok(partnerMatchingService.getApplicationDetail(applicationId));
+    }
+
     private Long getMemberId(HttpServletRequest req) {
         Object attr = req.getAttribute("memberId");
         if (attr instanceof Long id) return id;

--- a/src/main/java/com/example/off/domain/partnerRecruit/dto/ApplicationDetailResponse.java
+++ b/src/main/java/com/example/off/domain/partnerRecruit/dto/ApplicationDetailResponse.java
@@ -1,0 +1,34 @@
+package com.example.off.domain.partnerRecruit.dto;
+
+import com.example.off.domain.partnerRecruit.PartnerApplication;
+import com.example.off.domain.role.Role;
+
+public record ApplicationDetailResponse(
+        Long applicationId,
+        Long projectId,
+        String projectName,
+        String projectDescription,
+        Long partnerId,
+        String partnerNickname,
+        String partnerIntroduction,
+        Role role,
+        Long cost,
+        String status,
+        boolean isFromProject
+) {
+    public static ApplicationDetailResponse from(PartnerApplication application) {
+        return new ApplicationDetailResponse(
+                application.getId(),
+                application.getPartnerRecruit().getProject().getId(),
+                application.getPartnerRecruit().getProject().getName(),
+                application.getPartnerRecruit().getProject().getDescription(),
+                application.getMember().getId(),
+                application.getMember().getNickname(),
+                application.getMember().getSelfIntroduction(),
+                application.getPartnerRecruit().getRole(),
+                application.getPartnerRecruit().getCost(),
+                application.getApplicationStatus().name(),
+                application.getIsFromProject()
+        );
+    }
+}

--- a/src/main/java/com/example/off/domain/partnerRecruit/service/PartnerMatchingService.java
+++ b/src/main/java/com/example/off/domain/partnerRecruit/service/PartnerMatchingService.java
@@ -181,6 +181,13 @@ public class PartnerMatchingService {
         return PartnerProfileResponse.of(partner);
     }
 
+    @Transactional(readOnly = true)
+    public ApplicationDetailResponse getApplicationDetail(Long applicationId) {
+        PartnerApplication application = partnerApplicationRepository.findById(applicationId)
+                .orElseThrow(() -> new OffException(ResponseCode.APPLICATION_NOT_FOUND));
+        return ApplicationDetailResponse.from(application);
+    }
+
     private Role parseRole(String roleStr) {
         return switch (roleStr.toLowerCase()) {
             case "planner" -> Role.PM;


### PR DESCRIPTION
## Summary
알림에서 applicationId만으로 프로젝트 정보를 포함한 지원 상세 정보를 조회할 수 있는 API 추가

## Problem
- 파트너 지원 알림에는 `/payments/prepare/{applicationId}` URL만 포함됨
- 프론트엔드에서 프로젝트 정보를 알 수 없어 화면 표시 불가

## Solution
### ApplicationDetailResponse
- 지원 정보 + 프로젝트 정보를 함께 반환하는 DTO

### GET /applications/{applicationId}
- 지원 상세 정보 조회 API 추가
- 프로젝트 ID, 이름, 설명 포함
- 파트너 정보, 역할, 비용, 상태 포함

## API 예시

### 요청
```http
GET /applications/123
Authorization: Bearer {token}
```

### 응답
```json
{
  "success": true,
  "code": 200,
  "data": {
    "applicationId": 123,
    "projectId": 45,
    "projectName": "프로젝트 매칭 플랫폼",
    "projectDescription": "...",
    "partnerId": 3,
    "partnerNickname": "풀스택개발자",
    "partnerIntroduction": "...",
    "role": "DEV",
    "cost": 12000000,
    "status": "WAITING",
    "isFromProject": false
  }
}
```

## Use Case
```javascript
// 1. 알림에서 applicationId 추출
const applicationId = notification.redirectUrl.split('/').pop();

// 2. 지원 정보 조회 (프로젝트 정보 포함!)
const { data } = await fetch(`/applications/${applicationId}`);

// 3. 프로젝트 ID 및 모든 정보 사용 가능
console.log(data.projectId);  // 45
console.log(data.projectName);  // "프로젝트 매칭 플랫폼"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)