### PR TITLE
Fix: CONTACT 채팅방 목록 조회 500 오류 해결

### DIFF
--- a/src/main/java/com/example/off/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/example/off/domain/chat/repository/ChatRoomMemberRepository.java
@@ -13,15 +13,17 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
     @Query("SELECT crm FROM ChatRoomMember crm " +
             "JOIN FETCH crm.chatRoom cr " +
             "LEFT JOIN FETCH cr.project " +
+            "JOIN FETCH crm.member " +
             "WHERE crm.member.id = :memberId AND cr.chatType = :chatType")
     List<ChatRoomMember> findAllByMember_IdAndChatRoom_ChatType(
             @Param("memberId") Long memberId,
             @Param("chatType") ChatType chatType
     );
 
-    @Query("SELECT cp FROM ChatRoomMember cp " +
-            "JOIN FETCH cp.member " +
-            "WHERE cp.chatRoom.id = :roomId AND cp.member.id != :myId")
+    @Query("SELECT crm FROM ChatRoomMember crm " +
+            "JOIN FETCH crm.member " +
+            "JOIN FETCH crm.chatRoom cr " +
+            "WHERE cr.id = :roomId AND crm.member.id != :myId")
     Optional<ChatRoomMember> findOpponentByRoomIdAndMyId(
             @Param("roomId") Long roomId,
             @Param("myId") Long myId


### PR DESCRIPTION
## 문제
- CONTACT type 채팅방 목록 조회 시 500 오류 발생
- 참여자는 2명으로 정상이지만 LAZY loading으로 인한 오류

## 해결
- `ChatRoomMemberRepository`의 모든 쿼리에 JOIN FETCH 추가
- `findAllByMember_IdAndChatRoom_ChatType`: `JOIN FETCH crm.member` 추가
- `findOpponentByRoomIdAndMyId`: `JOIN FETCH crm.chatRoom` 추가

## 변경사항
- ChatRoomMemberRepository.java

## 테스트
- [ ] GET /chat/rooms?type=CONTACT 정상 응답 확인
- [ ] 채팅방 참여자 2명 확인

🤖 Generated with Claude Code