### PR TITLE
Fix: ChatRoomListResponse JSON 직렬화 오류 해결

### DIFF
--- a/src/main/java/com/example/off/domain/chat/dto/ChatRoomListResponse.java
+++ b/src/main/java/com/example/off/domain/chat/dto/ChatRoomListResponse.java
@@ -17,6 +17,7 @@ import java.util.List;
 public class ChatRoomListResponse {
     List<ChatRoomResponse> chatRoomResponses;
 
+    @Getter
     public static class ChatRoomResponse{
 
         @Schema(description = "채팅방 아이디", example = "105")
@@ -27,6 +28,7 @@ public class ChatRoomListResponse {
         private LastMessageInfo lastMessageInfo;
         private int unReadCount;
 
+        @Getter
         public static class ChatProjectInfo {
             private Long id;
             private String name;
@@ -39,6 +41,7 @@ public class ChatRoomListResponse {
                 return new ChatProjectInfo(project.getId(), project.getName());
             }
         }
+        @Getter
         public static class LastMessageInfo {
             private String content;
             private LocalDateTime createdAt;


### PR DESCRIPTION
## 문제
- GET /chat/rooms?type=CONTACT 호출 시 500 오류
- `HttpMessageConversionException: Type definition error`
- Jackson이 ChatRoomResponse를 JSON으로 직렬화 실패

## 원인
- ChatRoomResponse, ChatProjectInfo, LastMessageInfo 클래스에 **@Getter가 없음**
- Jackson은 getter를 통해 필드를 직렬화하므로 getter 없으면 오류 발생

## 해결
- 3개 inner class 모두에 `@Getter` 추가
  - ChatRoomResponse
  - ChatProjectInfo
  - LastMessageInfo

## 테스트
- [x] 로컬에서 수정 확인
- [ ] 배포 후 GET /chat/rooms?type=CONTACT 정상 응답 확인

🤖 Generated with Claude Code