### PR TITLE
Fix: Add @Getter and @JsonProperty to ChatMessageDetailResponse for JSON serialization

### DIFF
--- a/src/main/java/com/example/off/domain/chat/dto/ChatMessageDetailResponse.java
+++ b/src/main/java/com/example/off/domain/chat/dto/ChatMessageDetailResponse.java
@@ -1,20 +1,25 @@
 package com.example.off.domain.chat.dto;
 
 import com.example.off.domain.chat.Message;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Getter
 public class ChatMessageDetailResponse {
     private Long id;
     private OpponentResponse opponentResponse;
     private List<ChatMessageResponse> chatMessageResponses;
     private boolean hasNext;
 
+    @Getter
     public static class ChatMessageResponse{
         private Long id;
         private String content;
         private LocalDateTime createdAt;
+        @JsonProperty("isMine")
         private boolean isMine;
 
         public ChatMessageResponse(Long id, String content, LocalDateTime createdAt, boolean isMine) {


### PR DESCRIPTION
## Summary
- `ChatMessageDetailResponse` 및 내부 클래스 `ChatMessageResponse`에 `@Getter` 추가 — Jackson이 private 필드를 직렬화하지 못해 발생한 500 에러 수정
- `boolean isMine` 필드에 `@JsonProperty("isMine")` 추가 — Lombok `@Getter`가 생성하는 `isMine()` 메서드를 Jackson이 `mine`으로 직렬화하는 문제 방지

## Test plan
- [ ] `GET /chat/rooms/{roomId}` 요청 시 500 에러 없이 정상 응답 확인
- [ ] 응답 JSON의 `chatMessageResponses` 내 필드가 `isMine`으로 내려오는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)