### PR TITLE
Fix: Handle NonUniqueResultException in findOpponentByRoomIdAndMyId

### DIFF
--- a/src/main/java/com/example/off/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/example/off/domain/chat/repository/ChatRoomMemberRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, Long> {
     @Query("SELECT crm FROM ChatRoomMember crm " +
@@ -24,7 +23,7 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
             "JOIN FETCH crm.member " +
             "JOIN FETCH crm.chatRoom cr " +
             "WHERE cr.id = :roomId AND crm.member.id != :myId")
-    Optional<ChatRoomMember> findOpponentByRoomIdAndMyId(
+    List<ChatRoomMember> findOpponentByRoomIdAndMyId(
             @Param("roomId") Long roomId,
             @Param("myId") Long myId
     );

--- a/src/main/java/com/example/off/domain/chat/service/ChatService.java
+++ b/src/main/java/com/example/off/domain/chat/service/ChatService.java
@@ -42,8 +42,9 @@ public class ChatService {
                     ChatRoom room = participation.getChatRoom();
                     Project project = room.getProject();
 
-                    ChatRoomMember opponent = chatRoomMemberRepository.findOpponentByRoomIdAndMyId(room.getId(), memberId)
-                            .orElseThrow(() -> new OffException(ResponseCode.OPPONENT_NOT_FOUND));
+                    List<ChatRoomMember> opponents = chatRoomMemberRepository.findOpponentByRoomIdAndMyId(room.getId(), memberId);
+                    if (opponents.isEmpty()) throw new OffException(ResponseCode.OPPONENT_NOT_FOUND);
+                    ChatRoomMember opponent = opponents.get(0);
 
                     Message lastMessage = messageRepository.findFirstByChatRoom_IdOrderByCreatedAtDesc(room.getId())
                             .orElse(null);
@@ -80,8 +81,9 @@ public class ChatService {
             messages = messages.subList(0, size);
         }
 
-        ChatRoomMember opponentMember = chatRoomMemberRepository.findOpponentByRoomIdAndMyId(roomId, memberId)
-                .orElseThrow(() -> new OffException(ResponseCode.OPPONENT_NOT_FOUND));
+        List<ChatRoomMember> opponentMembers = chatRoomMemberRepository.findOpponentByRoomIdAndMyId(roomId, memberId);
+        if (opponentMembers.isEmpty()) throw new OffException(ResponseCode.OPPONENT_NOT_FOUND);
+        ChatRoomMember opponentMember = opponentMembers.get(0);
 
         List<ChatMessageDetailResponse.ChatMessageResponse> messageList = messages.stream()
                 .map(m -> ChatMessageDetailResponse
@@ -104,8 +106,9 @@ public class ChatService {
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new OffException(ResponseCode.MEMBER_NOT_FOUND));
-        ChatRoomMember opponent = chatRoomMemberRepository.findOpponentByRoomIdAndMyId(room.getId(), memberId)
-                .orElseThrow(() -> new OffException(ResponseCode.OPPONENT_NOT_FOUND));
+        List<ChatRoomMember> opponents = chatRoomMemberRepository.findOpponentByRoomIdAndMyId(room.getId(), memberId);
+        if (opponents.isEmpty()) throw new OffException(ResponseCode.OPPONENT_NOT_FOUND);
+        ChatRoomMember opponent = opponents.get(0);
 
         Message message = new Message(content, false, member, room);
         Message savedMessage = messageRepository.save(message);


### PR DESCRIPTION
## Summary
- `findOpponentByRoomIdAndMyId` 반환 타입을 `Optional` → `List`로 변경
- `Optional` 반환 시 Spring Data JPA 내부에서 `getSingleResult()` 사용 → 결과가 2개 이상이면 `NonUniqueResultException` 발생
- CONTACT 채팅방에 중복 데이터가 존재하는 경우 500 에러 발생하던 문제 수정
- 서비스 레이어에서 리스트의 첫 번째 요소를 사용하도록 변경

## Test plan
- [ ] `GET /chat/rooms?type=CONTACT` 요청 시 500 에러 없이 정상 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)