### PR TITLE
Fix: Change findWorkingProject return type to List to handle NonUniqueResultException

### DIFF
--- a/src/main/java/com/example/off/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/off/domain/member/service/MemberService.java
@@ -15,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 import static com.example.off.domain.member.Member.NICKNAME_MAX_LENGTH;
 import static com.example.off.domain.member.Member.SELF_INTRO_MAX_LENGTH;
@@ -32,7 +31,7 @@ public class MemberService {
         Member member = findMember(memberId); //회원 찾기
         //현재 시점을 기준으로 진행중인 project 찾기
         LocalDate now = LocalDate.now();
-        Optional<ProjectMember> workingProjectList = projectMemberRepository.findWorkingProject(memberId, now);
+        List<ProjectMember> workingProjectList = projectMemberRepository.findWorkingProject(memberId, now);
         if (workingProjectList.isEmpty()) //진행 중인 프로젝트 없음.
             return ProfileResponse.of(member, null);
 
@@ -41,8 +40,8 @@ public class MemberService {
             member.startWorking();
         }
 
-        //프로젝트를 진행 중인 경우
-        String workingProjectName = workingProjectList.get().getProject().getName();
+        //프로젝트를 진행 중인 경우 (여러 개면 종료일이 가장 빠른 것 사용)
+        String workingProjectName = workingProjectList.get(0).getProject().getName();
         return ProfileResponse.of(member, workingProjectName);
     }
 

--- a/src/main/java/com/example/off/domain/projectMember/repository/ProjectMemberRepository.java
+++ b/src/main/java/com/example/off/domain/projectMember/repository/ProjectMemberRepository.java
@@ -28,7 +28,7 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Lo
                   and pm.project.status = 'IN_PROGRESS'
                 order by pm.project.end asc
             """)
-    Optional<ProjectMember> findWorkingProject(
+    List<ProjectMember> findWorkingProject(
             @Param("memberId") Long memberId,
             @Param("now") LocalDate now);
 }


### PR DESCRIPTION
## Summary
- `ProjectMemberRepository.findWorkingProject`의 반환 타입을 `Optional<ProjectMember>` → `List<ProjectMember>`로 변경
- 한 멤버가 여러 `IN_PROGRESS` 프로젝트에 동시에 속할 경우 발생하던 `NonUniqueResultException` (500 에러) 수정
- 서비스에서 `get()` → `get(0)` 으로 변경하여 종료일 기준 가장 빠른 프로젝트 이름을 반환 (쿼리에 `order by pm.project.end asc` 적용됨)

## Test plan
- [ ] 진행 중인 프로젝트가 없는 계정으로 `/members/me` 조회 → 정상 응답 확인
- [ ] 진행 중인 프로젝트가 1개인 계정으로 `/members/me` 조회 → 프로젝트명 포함 정상 응답 확인
- [ ] 진행 중인 프로젝트가 2개 이상인 계정으로 `/members/me` 조회 → 500 에러 없이 정상 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)