### PR TITLE
Fix: Allow project members to edit project and expose projectMemberId in response

### DIFF
--- a/src/main/java/com/example/off/domain/project/dto/ProjectDetailResponse.java
+++ b/src/main/java/com/example/off/domain/project/dto/ProjectDetailResponse.java
@@ -38,6 +38,7 @@ public class ProjectDetailResponse {
         private Long taskId;
         private String name;
         private String description;
+        private Long assigneeProjectMemberId;
         private String assigneeName;
         private int progressPercent;
         private List<ToDoSummary> toDoList;
@@ -54,6 +55,7 @@ public class ProjectDetailResponse {
     @Getter
     @AllArgsConstructor
     public static class MemberSummary {
+        private Long projectMemberId;
         private Long memberId;
         private String nickname;
         private String profileImage;

--- a/src/main/java/com/example/off/domain/project/service/ProjectService.java
+++ b/src/main/java/com/example/off/domain/project/service/ProjectService.java
@@ -356,6 +356,7 @@ public class ProjectService {
                             : (int) (t.getToDoList().stream().filter(ToDo::getIsDone).count() * 100 / t.getToDoList().size());
                     return new ProjectDetailResponse.TaskSummary(
                             t.getId(), t.getName(), t.getDescription(),
+                            t.getProjectMember().getId(),
                             t.getProjectMember().getMember().getNickname(),
                             taskProgress, todos);
                 })
@@ -363,7 +364,7 @@ public class ProjectService {
 
         List<ProjectDetailResponse.MemberSummary> members = project.getProjectMembers().stream()
                 .map(pm -> new ProjectDetailResponse.MemberSummary(
-                        pm.getMember().getId(), pm.getMember().getNickname(),
+                        pm.getId(), pm.getMember().getId(), pm.getMember().getNickname(),
                         pm.getMember().getProfileImage(), pm.getRole()))
                 .toList();
 
@@ -383,7 +384,9 @@ public class ProjectService {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new OffException(ResponseCode.PROJECT_NOT_FOUND));
 
-        if (!project.getCreator().getId().equals(memberId)) {
+        boolean isCreator = project.getCreator().getId().equals(memberId);
+        boolean isMember = projectMemberRepository.existsByProject_IdAndMember_Id(projectId, memberId);
+        if (!isCreator && !isMember) {
             throw new OffException(ResponseCode.UNAUTHORIZED_ACCESS);
         }
 


### PR DESCRIPTION
## Summary
- `ProjectService.updateIntroduction`: creator만 허용하던 권한 체크를 프로젝트 멤버도 허용하도록 변경
- `ProjectDetailResponse.MemberSummary`: `projectMemberId` 필드 추가 (프론트에서 태스크 생성/수정 시 담당자 ID로 사용)
- `ProjectDetailResponse.TaskSummary`: `assigneeProjectMemberId` 필드 추가 (태스크 수정 시 현재 담당자의 `projectMemberId` 참조 가능)

## Root Cause
- **프로젝트 수정 실패**: `updateIntroduction`이 `project.creator` 여부만 검사해 creator가 아닌 프로젝트 멤버는 항상 `UNAUTHORIZED_ACCESS` 발생
- **태스크 수정 실패**: `CreateTaskRequest` / `UpdateTaskRequest`가 담당자 식별에 `projectMemberId`(ProjectMember PK)를 요구하는데, `ProjectDetailResponse`는 `memberId`만 반환해 프론트가 올바른 ID를 알 수 없었음

## Test plan
- [ ] creator가 아닌 프로젝트 멤버 계정으로 `/projects/{id}/introduction` PATCH → 200 정상 응답 확인
- [ ] 프로젝트 멤버가 아닌 계정으로 동일 API 호출 → 403 응답 확인
- [ ] `GET /projects/{id}` 응답의 `members[].projectMemberId`, `tasks[].assigneeProjectMemberId` 값 포함 여부 확인
- [ ] 해당 `projectMemberId`로 태스크 생성/수정 요청 → 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)