### PR TITLE
Fix: Format notification createdAt as yyyy-MM-dd HH:mm:ss

### DIFF
--- a/src/main/java/com/example/off/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/example/off/domain/notification/dto/NotificationResponse.java
@@ -2,6 +2,8 @@ package com.example.off.domain.notification.dto;
 
 import com.example.off.domain.notification.Notification;
 
+import java.time.format.DateTimeFormatter;
+
 public record NotificationResponse(
         Long notificationId,
         String title,
@@ -11,6 +13,8 @@ public record NotificationResponse(
         String createdAt,
         boolean isRead
 ) {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
     public static NotificationResponse from(Notification notification) {
         return new NotificationResponse(
                 notification.getId(),
@@ -18,7 +22,7 @@ public record NotificationResponse(
                 notification.getNotificationType().name(),
                 notification.getContent(),
                 notification.getUrl(),
-                notification.getCreatedAt().toString(),
+                notification.getCreatedAt().format(FORMATTER),
                 notification.getIsRead()
         );
     }


### PR DESCRIPTION
## Summary
- `NotificationResponse.createdAt` 포맷을 `LocalDateTime.toString()` → `DateTimeFormatter("yyyy-MM-dd HH:mm:ss")` 으로 변경

## Before / After
| | 변경 전 | 변경 후 |
|---|---|---|
| `createdAt` 출력값 | `2026-02-19T14:30:00.123456789` | `2026-02-19 14:30:00` |

## Test plan
- [ ] 알림 발송 후 `GET /notifications` 응답의 `createdAt` 포맷 확인 (`yyyy-MM-dd HH:mm:ss`)
- [ ] WebSocket 실시간 알림 수신 시 `createdAt` 포맷 동일 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)