### PR TITLE
Fix: Resolve multiple bugs found in code review

### DIFF
--- a/src/main/java/com/example/off/common/config/FilterConfig.java
+++ b/src/main/java/com/example/off/common/config/FilterConfig.java
@@ -29,7 +29,8 @@ public class FilterConfig {
                 "/notifications", "/notifications/*",
                 "/home",
                 "/partners/*",
-                "/invitations/*", "/invitations/*/*"
+                "/invitations/*", "/invitations/*/*",
+                "/applications/*"
         );
 
         // 다른 필터들보다 먼저

--- a/src/main/java/com/example/off/common/interceptor/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/example/off/common/interceptor/StompAuthChannelInterceptor.java
@@ -1,7 +1,9 @@
 package com.example.off.common.interceptor;
 
 import com.example.off.common.auth.StompPrincipal;
+import com.example.off.common.exception.OffException;
 import com.example.off.common.jwt.JwtTokenProvider;
+import com.example.off.common.response.ResponseCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
@@ -20,17 +22,16 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
 
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-        if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) { // 연결 시점에만 검증!
-//            String token = accessor.getFirstNativeHeader("Authorization");
-//            if (token == null || token.isBlank()) {
-//                throw new OffException(TOKEN_NOT_FOUND);
-//            }
-//            Long memberId = jwtTokenProvider.getMemberIdFromToken(token);
-//            if(memberId == null){
-//                throw new OffException(INVALID_TOKEN);
-//            }
-//            accessor.setUser(new StompPrincipal(memberId.toString()));
-            accessor.setUser(new StompPrincipal("1"));
+        if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
+            String token = accessor.getFirstNativeHeader("Authorization");
+            if (token == null || token.isBlank()) {
+                throw new OffException(ResponseCode.TOKEN_NOT_FOUND);
+            }
+            Long memberId = jwtTokenProvider.getMemberIdFromToken(token);
+            if (memberId == null) {
+                throw new OffException(ResponseCode.INVALID_TOKEN);
+            }
+            accessor.setUser(new StompPrincipal(memberId.toString()));
         }
         return message;
     }

--- a/src/main/java/com/example/off/domain/chat/dto/ChatInitialSendResponse.java
+++ b/src/main/java/com/example/off/domain/chat/dto/ChatInitialSendResponse.java
@@ -2,6 +2,8 @@ package com.example.off.domain.chat.dto;
 
 import com.example.off.domain.chat.ChatRoom;
 import com.example.off.domain.chat.Message;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -13,7 +15,9 @@ public class ChatInitialSendResponse {
     private Long chatRoomId;
     private Long messageId;
     private String content;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
+    @JsonProperty("isMine")
     private boolean isMine;
 
     public static ChatInitialSendResponse of(ChatRoom room, SendMessageResponse response) {

--- a/src/main/java/com/example/off/domain/chat/dto/ChatMessageDetailResponse.java
+++ b/src/main/java/com/example/off/domain/chat/dto/ChatMessageDetailResponse.java
@@ -1,6 +1,7 @@
 package com.example.off.domain.chat.dto;
 
 import com.example.off.domain.chat.Message;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
@@ -18,6 +19,7 @@ public class ChatMessageDetailResponse {
     public static class ChatMessageResponse{
         private Long id;
         private String content;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private LocalDateTime createdAt;
         @JsonProperty("isMine")
         private boolean isMine;

--- a/src/main/java/com/example/off/domain/chat/dto/ChatRoomListResponse.java
+++ b/src/main/java/com/example/off/domain/chat/dto/ChatRoomListResponse.java
@@ -5,6 +5,7 @@ import com.example.off.domain.chat.ChatRoomMember;
 import com.example.off.domain.chat.ChatType;
 import com.example.off.domain.chat.Message;
 import com.example.off.domain.project.Project;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -44,6 +45,7 @@ public class ChatRoomListResponse {
         @Getter
         public static class LastMessageInfo {
             private String content;
+            @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
             private LocalDateTime createdAt;
 
             public LastMessageInfo(String content, LocalDateTime createdAt) {

--- a/src/main/java/com/example/off/domain/chat/dto/SendMessageResponse.java
+++ b/src/main/java/com/example/off/domain/chat/dto/SendMessageResponse.java
@@ -1,6 +1,8 @@
 package com.example.off.domain.chat.dto;
 
 import com.example.off.domain.chat.Message;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -9,7 +11,9 @@ import java.time.LocalDateTime;
 public class SendMessageResponse {
     private Long id;
     private String content;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
+    @JsonProperty("isMine")
     private boolean isMine;
 
     public SendMessageResponse(Long id, String content, LocalDateTime createdAt, boolean isMine) {

--- a/src/main/java/com/example/off/domain/member/dto/UpdateProfileResponse.java
+++ b/src/main/java/com/example/off/domain/member/dto/UpdateProfileResponse.java
@@ -1,6 +1,7 @@
 package com.example.off.domain.member.dto;
 
 import com.example.off.domain.member.Member;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class UpdateProfileResponse {
     private Long memberId;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime updatedAt;
 
     public static UpdateProfileResponse from(Member member) {

--- a/src/main/java/com/example/off/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/off/domain/member/service/MemberService.java
@@ -26,7 +26,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final ProjectMemberRepository projectMemberRepository;
 
-    @Transactional(readOnly = true)
+    @Transactional
     public ProfileResponse getMyProfile(Long memberId){
         Member member = findMember(memberId); //회원 찾기
         //현재 시점을 기준으로 진행중인 project 찾기

--- a/src/main/java/com/example/off/domain/partnerRecruit/controller/PartnerMatchingController.java
+++ b/src/main/java/com/example/off/domain/partnerRecruit/controller/PartnerMatchingController.java
@@ -68,9 +68,11 @@ public class PartnerMatchingController {
     @GetMapping("/applications/{applicationId}")
     @CustomExceptionDescription(SwaggerResponseDescription.GET_PARTNER_PROFILE)
     public BaseResponse<ApplicationDetailResponse> getApplicationDetail(
-            @PathVariable Long applicationId
+            @PathVariable Long applicationId,
+            HttpServletRequest httpServletRequest
     ) {
-        return BaseResponse.ok(partnerMatchingService.getApplicationDetail(applicationId));
+        Long memberId = getMemberId(httpServletRequest);
+        return BaseResponse.ok(partnerMatchingService.getApplicationDetail(memberId, applicationId));
     }
 
     private Long getMemberId(HttpServletRequest req) {

--- a/src/main/java/com/example/off/domain/partnerRecruit/service/PartnerMatchingService.java
+++ b/src/main/java/com/example/off/domain/partnerRecruit/service/PartnerMatchingService.java
@@ -182,9 +182,16 @@ public class PartnerMatchingService {
     }
 
     @Transactional(readOnly = true)
-    public ApplicationDetailResponse getApplicationDetail(Long applicationId) {
+    public ApplicationDetailResponse getApplicationDetail(Long memberId, Long applicationId) {
         PartnerApplication application = partnerApplicationRepository.findById(applicationId)
                 .orElseThrow(() -> new OffException(ResponseCode.APPLICATION_NOT_FOUND));
+
+        Long creatorId = application.getPartnerRecruit().getProject().getCreator().getId();
+        Long applicantId = application.getMember().getId();
+        if (!memberId.equals(creatorId) && !memberId.equals(applicantId)) {
+            throw new OffException(ResponseCode.UNAUTHORIZED_ACCESS);
+        }
+
         return ApplicationDetailResponse.from(application);
     }
 

--- a/src/main/java/com/example/off/domain/pay/dto/PreparePayRequest.java
+++ b/src/main/java/com/example/off/domain/pay/dto/PreparePayRequest.java
@@ -1,6 +1,9 @@
 package com.example.off.domain.pay.dto;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
 public record PreparePayRequest(
-        long applicationId
+        @NotNull @Positive Long applicationId
 ) {
 }

--- a/src/main/java/com/example/off/domain/pay/service/PayLogService.java
+++ b/src/main/java/com/example/off/domain/pay/service/PayLogService.java
@@ -42,6 +42,12 @@ public class PayLogService {
         PartnerApplication application = partnerApplicationRepository.findById(req.applicationId())
                 .orElseThrow(() -> new OffException(ResponseCode.APPLICATION_NOT_FOUND));
 
+        // 결제자가 프로젝트 creator인지 검증
+        Project project = application.getPartnerRecruit().getProject();
+        if (!project.getCreator().getId().equals(memberId)) {
+            throw new OffException(ResponseCode.UNAUTHORIZED_ACCESS);
+        }
+
         // 초대(isFromProject=true)인 경우: 파트너가 ACCEPT해야 결제 가능
         // 지원(isFromProject=false)인 경우: 기획자가 바로 결제 가능 (WAITING 상태)
         if (application.getIsFromProject() && application.getApplicationStatus() != ApplicationStatus.ACCEPT) {
@@ -109,6 +115,9 @@ public class PayLogService {
         Project project = recruit.getProject();
         Member payee = application.getMember();
 
+        if (projectMemberRepository.existsByProjectAndMember(project, payee)) {
+            throw new OffException(ResponseCode.ALREADY_PROJECT_MEMBER);
+        }
         ProjectMember projectMember = ProjectMember.of(project, payee);
         projectMemberRepository.save(projectMember);
 

--- a/src/main/java/com/example/off/domain/project/dto/ConfirmProjectRequest.java
+++ b/src/main/java/com/example/off/domain/project/dto/ConfirmProjectRequest.java
@@ -13,8 +13,10 @@ import java.util.List;
 public class ConfirmProjectRequest {
     @NotBlank
     private String name;
+    @NotBlank
     private String description;
     private Long projectTypeId = 1L;  // 앱개발로 고정 (1L = APP)
+    @NotBlank
     private String requirement;
     private String serviceSummary;
     @NotBlank

--- a/src/main/java/com/example/off/domain/project/dto/HomeResponse.java
+++ b/src/main/java/com/example/off/domain/project/dto/HomeResponse.java
@@ -1,6 +1,7 @@
 package com.example.off.domain.project.dto;
 
 import com.example.off.domain.role.Role;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -22,6 +23,7 @@ public class HomeResponse {
         private String endDate;
         private long dDay;
         private int progressPercent;
+        @JsonProperty("isRecruiting")
         private boolean isRecruiting;  // 모집 중인지 여부
         private List<RecruitInfo> recruitList;  // 모집 중인 역할 목록
     }

--- a/src/main/java/com/example/off/domain/project/dto/ProjectDetailResponse.java
+++ b/src/main/java/com/example/off/domain/project/dto/ProjectDetailResponse.java
@@ -2,6 +2,7 @@ package com.example.off.domain.project.dto;
 
 import com.example.off.domain.project.ProjectStatus;
 import com.example.off.domain.role.Role;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -49,6 +50,7 @@ public class ProjectDetailResponse {
     public static class ToDoSummary {
         private Long toDoId;
         private String content;
+        @JsonProperty("isDone")
         private boolean isDone;
     }
 

--- a/src/main/java/com/example/off/domain/project/service/ProjectService.java
+++ b/src/main/java/com/example/off/domain/project/service/ProjectService.java
@@ -409,10 +409,8 @@ public class ProjectService {
 
         project.complete();
 
-        // 1. projectCount 증가 - creator와 모든 projectMember
+        // 1. projectCount 증가 - 모든 projectMember (creator도 포함되어 있음)
         Member creator = project.getCreator();
-        creator.incrementProjectCount();
-
         for (ProjectMember pm : project.getProjectMembers()) {
             pm.getMember().incrementProjectCount();
         }

--- a/src/main/java/com/example/off/domain/task/dto/ToggleToDoResponse.java
+++ b/src/main/java/com/example/off/domain/task/dto/ToggleToDoResponse.java
@@ -1,5 +1,6 @@
 package com.example.off.domain.task.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,6 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ToggleToDoResponse {
     private Long toDoId;
+    @JsonProperty("isDone")
     private boolean isDone;
     private int taskProgressPercent;
 


### PR DESCRIPTION
## Summary

코드 리뷰에서 발견된 버그 17개 파일 수정

## 수정 내용

### 높음 (즉시 수정)
| 파일 | 수정 내용 |
|------|-----------|
| `MemberService` | `getMyProfile`에서 `@Transactional(readOnly=true)` → `@Transactional` 변경 — `startWorking()` 보정이 실제로 DB에 반영되지 않던 문제 수정 |
| `ProjectService` | `completeProject`에서 creator의 `projectCount`가 2번 증가하던 버그 수정 (creator가 ProjectMember에 포함되어 있어 중복 호출) |
| `StompAuthChannelInterceptor` | WebSocket JWT 인증 복원 — 하드코딩된 `memberId = "1"` 제거 |
| 채팅/태스크/홈 DTO | `boolean isMine/isDone/isRecruiting` 필드에 `@JsonProperty` 추가 — Jackson이 `is` 접두사를 제거해 `"mine"/"done"/"recruiting"`으로 직렬화되던 문제 수정 |

### 중간 (기능 영향)
| 파일 | 수정 내용 |
|------|-----------|
| `PayLogService.prepare` | 결제 요청자가 프로젝트 creator인지 검증 추가 |
| `PayLogService.completePayment` | `ProjectMember` 중복 생성 방어 — DB UNIQUE 위반 예외 대신 `ALREADY_PROJECT_MEMBER` 응답 |
| `PartnerMatchingService.getApplicationDetail` | 지원서 조회 권한 검증 추가 (creator 또는 지원자 본인만 조회 가능) |
| `PartnerMatchingController` | `getApplicationDetail`에 `memberId` 전달 |
| `FilterConfig` | `/applications/*` JWT 필터 경로 추가 |
| `ChatRoomListResponse`, `SendMessageResponse`, `ChatInitialSendResponse`, `ChatMessageDetailResponse`, `UpdateProfileResponse` | `LocalDateTime` 필드에 `@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")` 추가 |
| `ConfirmProjectRequest` | `description`, `requirement` 에 `@NotBlank` 추가 |
| `PreparePayRequest` | `applicationId` 타입 `long` → `Long`, `@NotNull @Positive` 추가 |

## Test plan
- [ ] 마이 프로필 조회 시 `isWorking` 불일치가 있는 계정에서 자동 보정 후 DB 반영 확인
- [ ] 프로젝트 완료 시 creator의 `projectCount`가 정확히 1 증가하는지 확인
- [ ] WebSocket 연결 시 JWT 토큰 없으면 연결 거부 확인
- [ ] 채팅 메시지 응답에서 `isMine`, `isDone` 키 이름 확인
- [ ] 홈 응답에서 `isRecruiting` 키 이름 확인
- [ ] `/applications/{id}` 조회 시 본인이 아닌 사람의 요청은 403 확인
- [ ] 결제 준비 시 creator가 아닌 멤버가 요청하면 403 확인
- [ ] 채팅 응답 날짜 포맷 `yyyy-MM-dd HH:mm:ss` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)