### PR TITLE
fix: CORS headers on JWT 401 & disable data.sql auto-run

### DIFF
--- a/src/main/java/com/example/off/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/off/common/jwt/JwtAuthenticationFilter.java
@@ -6,8 +6,17 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
+import java.util.Set;
 
 public class JwtAuthenticationFilter implements Filter {
+
+    private static final Set<String> ALLOWED_ORIGINS = Set.of(
+            "http://localhost:5173",
+            "http://localhost:3000",
+            "http://offf.kro.kr",
+            "https://offf.kro.kr",
+            "https://off-web-eosin.vercel.app"
+    );
 
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -30,6 +39,7 @@ public class JwtAuthenticationFilter implements Filter {
         String header = request.getHeader("Authorization");
 
         if (header == null || !header.startsWith("Bearer ")) {
+            setCorsHeaders(request, response);
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             response.setContentType("application/json;charset=UTF-8");
             response.getWriter().write("{\"success\":false,\"code\":401,\"message\":\"토큰이 필요합니다.\"}");
@@ -49,8 +59,18 @@ public class JwtAuthenticationFilter implements Filter {
 
             chain.doFilter(request, response);
         } catch (Exception e) {
+            setCorsHeaders(request, response);
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.getWriter().write("Invalid or expired token");
+            response.setContentType("application/json;charset=UTF-8");
+            response.getWriter().write("{\"success\":false,\"code\":401,\"message\":\"유효하지 않거나 만료된 토큰입니다.\"}");
+        }
+    }
+
+    private void setCorsHeaders(HttpServletRequest request, HttpServletResponse response) {
+        String origin = request.getHeader("Origin");
+        if (origin != null && ALLOWED_ORIGINS.contains(origin)) {
+            response.setHeader("Access-Control-Allow-Origin", origin);
+            response.setHeader("Access-Control-Allow-Credentials", "true");
         }
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,7 +9,7 @@ spring:
     driver-class-name: org.postgresql.Driver
   sql:
     init:
-      mode: always # data.sql이 중복 실행되어도 에러 안 나게 쿼리 짰는지 확인 필수!
+      mode: never
   jpa:
     defer-datasource-initialization: true
     hibernate:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,21 +1,21 @@
 -- =====================================================
--- 초기화: 모든 테이블 데이터 삭제 (FK 제약조건이 있으므로 순서 중요 또는 Disable FK Check)
+-- 초기화: 모든 테이블 데이터 삭제 (PostgreSQL)
 -- =====================================================
-SET FOREIGN_KEY_CHECKS = 0;
-TRUNCATE TABLE pay_log;
-TRUNCATE TABLE notification;
-TRUNCATE TABLE message;
-TRUNCATE TABLE chat_room_member;
-TRUNCATE TABLE chat_room;
-TRUNCATE TABLE to_do;
-TRUNCATE TABLE task;
-TRUNCATE TABLE partner_application;
-TRUNCATE TABLE partner_recruit;
-TRUNCATE TABLE project_member;
-TRUNCATE TABLE project;
-TRUNCATE TABLE portfolio;
-TRUNCATE TABLE member;
-SET FOREIGN_KEY_CHECKS = 1;
+TRUNCATE TABLE 
+    pay_log, 
+    notification, 
+    message, 
+    chat_room_member, 
+    chat_room, 
+    to_do, 
+    task, 
+    partner_application, 
+    partner_recruit, 
+    project_member, 
+    project, 
+    portfolio, 
+    member 
+RESTART IDENTITY CASCADE;
 
 -- =====================================================
 -- 시드 데이터: 모든 기능 테스트용 더미 데이터


### PR DESCRIPTION
## Summary
- JwtAuthenticationFilter에서 401 반환 시 CORS 헤더 추가 (배포 환경에서 cross-origin 요청 시 CORS 에러 발생 문제 해결)
- data.sql `mode: always` → `never`로 변경하여 배포/재시작 시 데이터 초기화 방지

## Test plan
- [ ] 배포된 프론트엔드에서 만료된/없는 토큰으로 요청 시 CORS 에러 대신 401 JSON 응답이 오는지 확인
- [ ] 서버 재시작 후 기존 DB 데이터가 유지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)